### PR TITLE
(#17) Fix Windows paths in Addons

### DIFF
--- a/source/Public/ConvertTo-TodoTxt.ps1
+++ b/source/Public/ConvertTo-TodoTxt.ps1
@@ -60,7 +60,7 @@
             # project - eg. '+rebuild' - can only have ONE + to be recognised as a project
             @{ "name" = "Project"; "regex" = "(?:^|\s)\+[a-z\d-_]+" },
             # addon - eg. 'due:2017-02-01'
-            @{ "name" = "Addon"; "regex" = "(?:^|\s)(\S+)\:((?!//)\S+)" }
+            @{ "name" = "Addon"; "regex" = "(?:^|\s)(\S+)\:((?!//|\\)\S+)" }
         )
     }
 

--- a/tests/public/ConvertTo-TodoTxt.Tests.ps1
+++ b/tests/public/ConvertTo-TodoTxt.Tests.ps1
@@ -24,6 +24,20 @@ Describe "Function Testing - $functionName" {
                     "expected"  = (New-Object -TypeName PSObject -Property @{ DoneDate = "2016-12-11"; Priority = "R"; CreatedDate="2016-10-09";
                                     Context = @( "home" ); Project = @( "travel" ); Addon = @{ "due" = "2016-12-03" }; Task = "Go to Ewok planet" })
                 },
+                @{  "name"     = "Windows type file path in an addon";
+                    "todo"     = "x 2016-12-11 (r) 2016-10-09 Go to Ewok planet @home +travel due:2016-12-03 file:c:\temp\test.txt";
+                    "expected" = (New-Object -TypeName PSObject -Property @{ DoneDate = "2016-12-11"; Priority = "R"; CreatedDate = "2016-10-09";
+                            Context = @( "home" ); Project = @( "travel" ); Addon = @{ "due" = "2016-12-03"; "file" = "c:\temp\test.txt" };
+                            Task = "Go to Ewok planet"
+                        })
+                },
+                @{  "name"     = "Linux type file path in an addon";
+                    "todo"     = "x 2016-12-11 (r) 2016-10-09 Go to Ewok planet @home +travel due:2016-12-03 file:c:/temp/test.txt";
+                    "expected" = (New-Object -TypeName PSObject -Property @{ DoneDate = "2016-12-11"; Priority = "R"; CreatedDate = "2016-10-09";
+                            Context = @( "home" ); Project = @( "travel" ); Addon = @{ "due" = "2016-12-03"; "file" = "c:/temp/test.txt" };
+                            Task = "Go to Ewok planet"
+                        })
+                },
                 @{  "name"      = "just task";
                     "todo"      = "Go to Ewok planet";
                     "expected"  = (New-Object -TypeName PSObject -Property @{ CreatedDate = $todaysDate; Task = "Go to Ewok planet"} )


### PR DESCRIPTION
This adds the Windows path separator to be ignored in the Addon regex.

Fixes #17.